### PR TITLE
 Removed 'child_process' NPM module from dependencies: redundant => module included in standard node.js API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,11 +19,6 @@
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-7.2.1.tgz",
       "integrity": "sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ=="
     },
-    "child_process": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/child_process/-/child_process-1.0.2.tgz",
-      "integrity": "sha1-sffn/HPSXn/R1FWtyU4UODAYK1o="
-    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   "license": "MIT",
   "dependencies": {
     "@elian-wonhalf/pretty-logger": "^1.0.1",
-    "child_process": "^1.0.2",
     "discord.js": "^11.5.1",
     "fs": "0.0.1-security",
     "mysql": "^2.17.1"


### PR DESCRIPTION
Tests done; bot still works as expected.

Explanation:

I removed 'child_process' NPM module from the project's dependencies because it is included in the node.js standard API (https://nodejs.org/api/child_process.html) and it seemed redundant.

The current NPM repo (https://www.npmjs.com/package/child_process) turns out to be an empty one that is left as is for security reasons (an eventual give away of the NPM repo seems considered if we trust the README, so in my opinion it is better to remove it now before getting an eventual wrong package).

Apart that, great bot and great server :)

aosync#3115